### PR TITLE
refactor(config): add runtime validation for DATABASE_URL in Drizzle …

### DIFF
--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,11 +1,15 @@
-import 'dotenv/config';
-import { defineConfig } from 'drizzle-kit';
+import "dotenv/config";
+import { defineConfig } from "drizzle-kit";
 
 export default defineConfig({
-  out: './drizzle',
-  schema: './src/db/schema.ts',
-  dialect: 'postgresql',
+  out: "./drizzle",
+  schema: "./src/db/schema.ts",
+  dialect: "postgresql",
   dbCredentials: {
-    url: process.env.DATABASE_URL!,
+    url: (() => {
+      if (!process.env.DATABASE_URL)
+        throw new Error("DATABASE_URL env var is required for Drizzle config");
+      return process.env.DATABASE_URL!;
+    })(),
   },
 });


### PR DESCRIPTION
Wrapped dbCredentials.url with an IIFE to throw an explicit error if DATABASE_URL is missing. Improves runtime safety and ensures early failure for misconfigured environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling to provide a clear message if the database connection URL is missing from the environment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->